### PR TITLE
fix cnumr/ecoindex_cli#226

### DIFF
--- a/ecoindex_scraper/scrap.py
+++ b/ecoindex_scraper/scrap.py
@@ -5,7 +5,7 @@ from time import sleep
 from typing import Dict, List, Tuple
 from warnings import filterwarnings
 
-import d as uc
+import undetected_chromedriver as uc
 from ecoindex.ecoindex import get_ecoindex
 from ecoindex.models import PageMetrics, PageType, Result, ScreenShot, WindowSize
 from pydantic.networks import HttpUrl

--- a/ecoindex_scraper/scrap.py
+++ b/ecoindex_scraper/scrap.py
@@ -5,7 +5,7 @@ from time import sleep
 from typing import Dict, List, Tuple
 from warnings import filterwarnings
 
-import undetected_chromedriver.v2 as uc
+import d as uc
 from ecoindex.ecoindex import get_ecoindex
 from ecoindex.models import PageMetrics, PageType, Result, ScreenShot, WindowSize
 from pydantic.networks import HttpUrl


### PR DESCRIPTION
Two commits because github.dev doesn't offer a way to amend crappy commit :laughing: 

---

The package isn't present in project dependencies in the `pyproject.toml`. You need to install, BUT since version `3.4.0` the `v2` has been removed:

> ### 3.4.0
>
> **Big update! be careful as it -potentially- could break your code.**
> …
> cleanup removed compat,v2 files and tests folder

source: https://github.com/ultrafunkamsterdam/undetected-chromedriver/blob/3a52c8cbdd1c0aada3e275ceae20514e072b52c2/README.md#340

## Workaround

You can install `3.2.0`

```
❯ poetry add undetected_chromedriver@3.2.0
```